### PR TITLE
wlan: Update BlueTooth co-existence parameters

### DIFF
--- a/wifi/WCNSS_qcom_cfg.ini
+++ b/wifi/WCNSS_qcom_cfg.ini
@@ -277,8 +277,8 @@ gScanAgingTime=0
 # Disable channel 165 for Indonesia
 #gIgnore_Chan165=1
 
-#btcStaticLenLeBt=120000
-#btcStaticLenLeWlan=30000
+btcStaticLenLeBt=120000
+btcStaticLenLeWlan=30000
 
 # Country code priority
 gCountryCodePriority=1


### PR DESCRIPTION
Update BlueTooth coexistence parameters so that Wi-Fi transfers are not
interrupted when searching for BlueTooth devices (b/8729132).

b/8284288
b/8729132
Signed-off-by: Iliyan Malchev malchev@google.com

Change-Id: I26551104fa66e596c8e3ed349b916be03e2aeb12
